### PR TITLE
chore(dep): 升级 vinyl-ftp，解决 Node 关于 minimatch 的 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "gulp-util": "^3.0.7",
     "through2": "^2.0.0",
-    "vinyl-ftp": "^0.4.5"
+    "vinyl-ftp": "^0.6.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
  Warning like this:
   `Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`